### PR TITLE
v0.7.0

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -13,4 +13,8 @@ PORT=3000
 PARALLEL=4
 SNAPSHOT=0
 
+BLOCK_PATH=
+TRANSACTION_PATH=
+TAGS_PATH=
+
 INDICES=["App-Name", "app", "domain", "namespace"]

--- a/.env.docker
+++ b/.env.docker
@@ -13,4 +13,8 @@ PORT=3000
 PARALLEL=4
 SNAPSHOT=0
 
+BLOCK_PATH=
+TRANSACTION_PATH=
+TAGS_PATH=
+
 INDICES=["App-Name", "app", "domain", "namespace"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ PORT=3000
 PARALLEL=4
 SNAPSHOT=0
 
+BLOCK_PATH=
+TRANSACTION_PATH=
+TAGS_PATH=
+
 INDICES=["App-Name", "app", "domain", "namespace"]
 ```
 

--- a/bin/copy.sh
+++ b/bin/copy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo COPYing files please wait
+
+export BLOCK_PATH=/mnt/51d141ea-be42-4823-92ec-5dce2074387b/arweave/snapshot/block.csv
+export TRANSACTION_PATH=/mnt/51d141ea-be42-4823-92ec-5dce2074387b/arweave/snapshot/transaction.csv
+export TAGS_PATH=/mnt/51d141ea-be42-4823-92ec-5dce2074387b/arweave/snapshot/tags.csv
+
+psql -d arweave <<EOF
+set statement_timeout to 60000000; commit;
+show statement_timeout;
+
+\COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM '$BLOCK_PATH' WITH (FORMAT CSV, HEADER, ESCAPE '\', DELIMITER '|', FORCE_NULL("height"));
+\COPY transactions ("format","id","signature","owner","owner_address","target","reward","last_tx","height","tags","quantity","content_type","data_size","data_root") FROM '$TRANSACTION_PATH' WITH (FORMAT CSV, HEADER, ESCAPE '\', DELIMITER '|', FORCE_NULL("format", "height", "data_size"));
+\COPY tags ("tx_id", "index", "name", "value") FROM '$TAGS_PATH' WITH (FORMAT CSV, HEADER, ESCAPE '\', DELIMITER '|', FORCE_NULL(index));
+EOF
+
+echo COPY complete

--- a/docs/SNAPSHOT.md
+++ b/docs/SNAPSHOT.md
@@ -38,18 +38,24 @@ arweave deploy snapshot.tar.gz
 
 ## Importing a Snapshot
 
-If you want to import a snapshot. You need to make sure import the `.csv` files into the `snapshot` folder. It should look something like.
+If you want to import a snapshot. You need to make sure to update your `.env` file to have the absolute paths to each CSV
 
 ```bash
-snapshot/block.csv
-snapshot/transaction.csv
-snapshot/tags.csv
+BLOCK_PATH=/path/to/snapshot/block.csv
+TRANSACTION_PATH=/path/to/snapshot/transaction.csv
+TAGS_PATH=/path/to/snapshot/tags.csv
 ```
 
 If you're downloading a `.tar.gz` file. You can decompress it by running.
 
 ```bash
 tar -zxf snapshot.tar.gz -C snapshot
+```
+
+Also make sure that the folder that holds the snapshot csv files has `rwx` permissions.
+
+```bash
+chmod +x /path/to/snapshot
 ```
 
 You can then run the import command.
@@ -64,11 +70,4 @@ If successful, it should output.
 info: [snapshot] successfully imported block.csv
 info: [snapshot] successfully imported transaction.csv
 info: [snapshot] successfully imported tags.csv
-```
-
-Make sure when running an actual Gateway you copy the `.snapshot` file from the `snapshot` folder into the root directory.
-
-```bash
-mkdir cache
-cp snapshot/.snapshot cache/.snapshot
 ```

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:restart": "npm run migrate:down && npm run migrate:latest && npm run dev:start",
     "dev:snapshot": "npm run dev:build && node dist/src/Snapshot.js",
     "dev:import": "npm run dev:build && node dist/src/Import.js",
+    "dev:gen-copy": "npm run dev:build && node dist/src/Copy.js",
     "rescan:cache": "npm run dev:build && node dist/src/Rescan.cache.js",
     "rescan:snapshot": "npm run dev:build && node dist/src/Rescan.snapshot.js",
     "rescan:temp": "npm run dev:build && node dist/src/Rescan.temp.js",

--- a/src/Copy.ts
+++ b/src/Copy.ts
@@ -1,0 +1,46 @@
+import 'colors';
+import {config} from 'dotenv';
+import {writeFileSync} from 'fs';
+import {indices, transactionOrder} from './utility/order.utility';
+
+config();
+
+export async function copy() {
+  console.log('Generating SQL for COPY commands in bin/copy.sh\n'.green.bold);
+
+  const txFields = transactionOrder
+      .concat(indices)
+      .map((field) => `"${field}"`);
+
+  const blocks = '\\COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM \'$BLOCK_PATH\' WITH (FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("height"));';
+
+  const transactions = `\\COPY transactions (${txFields.join(',')}) FROM '$TRANSACTION_PATH' WITH (FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL("format", "height", "data_size"));`;
+
+  const tags = '\\COPY tags ("tx_id", "index", "name", "value") FROM \'$TAGS_PATH\' WITH (FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL(index));';
+
+  const output = `#!/bin/bash
+echo COPYing files please wait
+
+export BLOCK_PATH=
+export TRANSACTION_PATH=
+export TAGS_PATH=
+
+psql -d arweave <<EOF
+
+set statement_timeout to 60000000; commit;
+show statement_timeout;
+
+${blocks}
+${transactions}
+${tags}
+
+EOF
+
+echo COPY complete`;
+
+  writeFileSync('bin/copy.sh', output);
+
+  console.log('Finished writing to bin/copy.sh\n'.green.bold);
+}
+
+(async () => await copy())();

--- a/src/Import.ts
+++ b/src/Import.ts
@@ -1,15 +1,22 @@
+import {config} from 'dotenv';
 import {log} from './utility/log.utility';
 import {importBlocks, importTransactions, importTags} from './database/import.database';
 
+config();
+
+export const BLOCK_PATH = process.env.BLOCK_PATH || 'snapshot/block.csv';
+export const TRANSACTION_PATH = process.env.TRANSACTION_PATH || 'snapshot/transaction.csv';
+export const TAGS_PATH = process.env.TAGS_PATH || 'snapshot/tags.csv';
+
 export async function importSnapshot() {
-  await importBlocks(`${process.cwd()}/snapshot/block.csv`);
-  log.info('[snapshot] successfully imported block.csv');
+  await importBlocks(BLOCK_PATH);
+  log.info(`[snapshot] successfully imported ${BLOCK_PATH}`);
 
-  await importTransactions(`${process.cwd()}/snapshot/transaction.csv`);
-  log.info('[snapshot] successfully imported transaction.csv');
+  await importTransactions(TRANSACTION_PATH);
+  log.info(`[snapshot] successfully imported ${TRANSACTION_PATH}`);
 
-  await importTags(`${process.cwd()}/snapshot/tags.csv`);
-  log.info('[snapshot] successfully imported tags.csv');
+  await importTags(TAGS_PATH);
+  log.info(`[snapshot] successfully imported ${TAGS_PATH}`);
 
   process.exit();
 }

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -7,20 +7,8 @@ config();
 
 export async function importBlocks(path: string) {
   return new Promise(async (resolve) => {
-    await connection.raw(`
-        COPY
-          blocks
-          (id, previous_block, mined_at, height, txs, extended)
-        FROM
-          '${path}'
-        WITH
-          (
-            FORMAT CSV,
-            ESCAPE '\\',
-            DELIMITER ',',
-            FORCE_NULL(height)
-          )
-        `);
+    const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("height"))';
+    await connection.raw(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM '${path}' WITH ${encoding}`);
 
     return resolve(true);
   });
@@ -32,19 +20,8 @@ export async function importTransactions(path: string) {
         .concat(indices)
         .map((field) => `"${field}"`);
 
-    await connection.raw(`
-        COPY
-          transactions
-          (${fields.join(',')})
-        FROM
-          '${path}'
-        WITH
-          (
-            FORMAT CSV,
-            ESCAPE '\\',
-            DELIMITER ',',
-            FORCE_NULL("format", "height", "data_size")
-          )`);
+    const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
+    await connection.raw(`COPY transactions (${fields.join(',')}) FROM '${path}' WITH ${encoding}`);
 
     return resolve(true);
   });
@@ -52,20 +29,8 @@ export async function importTransactions(path: string) {
 
 export async function importTags(path: string) {
   return new Promise(async (resolve) => {
-    await connection.raw(`
-        COPY
-          tags
-          (tx_id, index, name, value)
-        FROM
-          '${path}'
-        WITH
-          (
-            FORMAT CSV,
-            ESCAPE '\\',
-            DELIMITER ',',
-            FORCE_NULL(index)
-          )
-        `);
+    const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL(index))';
+    await connection.raw(`COPY tags ("tx_id", "index", "name", "value") FROM '${path}' WITH ${encoding}`);
 
     return resolve(true);
   });

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -1,10 +1,9 @@
 import {config} from 'dotenv';
+import {indices} from '../utility/order.utility';
 import {connection} from '../database/connection.database';
 import {transactionFields} from '../database/transaction.database';
 
 config();
-
-export const indices = JSON.parse(process.env.INDICES || '[]') as Array<string>;
 
 export async function importBlocks(path: string) {
   return new Promise(async (resolve) => {

--- a/src/database/rescan.database.ts
+++ b/src/database/rescan.database.ts
@@ -2,10 +2,11 @@ import ProgressBar from 'progress';
 import {existsSync, createReadStream, createWriteStream, readFileSync, writeFileSync, unlinkSync} from 'fs';
 import {split, mapSync} from 'event-stream';
 import {config} from 'dotenv';
+import {streams} from '../utility/csv.utility';
 import {log} from '../utility/log.utility';
 import {mkdir} from '../utility/file.utility';
 import {importTransactions, importTags} from '../database/import.database';
-import {storeTransaction, processAns, streams} from '../database/sync.database';
+import {storeTransaction, processAns} from '../database/sync.database';
 
 config();
 mkdir('snapshot');

--- a/src/database/sync.database.ts
+++ b/src/database/sync.database.ts
@@ -2,7 +2,8 @@ import ProgressBar from 'progress';
 import {DataItemJson} from 'arweave-bundles';
 import {existsSync, readFileSync, writeFileSync} from 'fs';
 import {config} from 'dotenv';
-import {indices, streams, initStreams, resetCacheStreams} from '../utility/csv.utility';
+import {serializeBlock, serializeTransaction, serializeAnsTransaction, serializeTags} from '../utility/serialize.utility';
+import {streams, initStreams, resetCacheStreams} from '../utility/csv.utility';
 import {log} from '../utility/log.utility';
 import {ansBundles} from '../utility/ans.utility';
 import {mkdir} from '../utility/file.utility';
@@ -13,8 +14,7 @@ import {block} from '../query/block.query';
 import {transaction, tagValue, Tag} from '../query/transaction.query';
 import {getDataFromChunks} from '../query/node.query';
 import {importBlocks, importTransactions, importTags} from './import.database';
-import {formatBlock} from './block.database';
-import {transactionFields, DatabaseTag, formatTransaction, formatAnsTransaction} from './transaction.database';
+import {DatabaseTag} from './transaction.database';
 
 config();
 mkdir('snapshot');
@@ -125,8 +125,7 @@ export async function parallelize(height: number) {
 export async function storeBlock(height: number) {
   try {
     const currentBlock = await block(height);
-    const fb = formatBlock(currentBlock);
-    const input = `"${fb.id}","${fb.previous_block}","${fb.mined_at}","${fb.height}","${fb.txs.replace(/"/g, '\\"')}","${fb.extended.replace(/"/g, '\\"')}"\n`;
+    const {formattedBlock, input} = serializeBlock(currentBlock, height);
 
     streams.block.cache.write(input);
 
@@ -135,7 +134,7 @@ export async function storeBlock(height: number) {
     }
 
     if (height > 0) {
-      await storeTransactions(JSON.parse(fb.txs) as Array<string>, height);
+      await storeTransactions(JSON.parse(formattedBlock.txs) as Array<string>, height);
     }
   } catch (error) {
     log.info(`[snapshot] could not retrieve block at height ${height}, retrying`);
@@ -159,16 +158,7 @@ export async function storeTransactions(txs: Array<string>, height: number) {
 export async function storeTransaction(tx: string, height: number, retry: boolean = true) {
   try {
     const currentTransaction = await transaction(tx);
-    const ft = formatTransaction(currentTransaction);
-    const preservedTags = JSON.parse(ft.tags) as Array<Tag>;
-
-    ft.tags = `${ft.tags.replace(/"/g, '\\"')}`;
-
-    const fields = transactionFields
-        .map((field) => `"${field === 'height' ? height : ft[field] ? ft[field] : ''}"`)
-        .concat(indices.map((ifield) => `"${ft[ifield] ? ft[ifield] : ''}"`));
-
-    const input = `${fields.join(',')}\n`;
+    const {formattedTransaction, preservedTags, input} = serializeTransaction(currentTransaction, height);
 
     streams.transaction.cache.write(input);
 
@@ -176,12 +166,12 @@ export async function storeTransaction(tx: string, height: number, retry: boolea
       streams.transaction.snapshot.write(input);
     }
 
-    storeTags(ft.id, preservedTags);
+    storeTags(formattedTransaction.id, preservedTags);
 
     const ans102 = tagValue(preservedTags, 'Bundle-Type') === 'ANS-102';
 
     if (ans102) {
-      await processAns(ft.id, height);
+      await processAns(formattedTransaction.id, height);
     }
   } catch (error) {
     console.log('');
@@ -219,16 +209,7 @@ export async function processAns(id: string, height: number, retry: boolean = tr
 export async function processANSTransaction(ansTxs: Array<DataItemJson>, height: number) {
   for (let i = 0; i < ansTxs.length; i++) {
     const ansTx = ansTxs[i];
-    const ft = formatAnsTransaction(ansTx);
-    ft.tags = `${ft.tags.replace(/"/g, '\\"')}`;
-
-    const ansTags = ansTx.tags;
-
-    const fields = transactionFields
-        .map((field) => `"${field === 'height' ? height : ft[field] ? ft[field] : ''}"`)
-        .concat(indices.map((ifield) => `"${ft[ifield] ? ft[ifield] : ''}"`));
-
-    const input = `${fields.join(',')}\n`;
+    const {ansTags, input} = serializeAnsTransaction(ansTx, height);
 
     streams.transaction.cache.write(input);
 
@@ -261,11 +242,8 @@ export async function processANSTransaction(ansTxs: Array<DataItemJson>, height:
 export function storeTags(tx_id: string, tags: Array<Tag>) {
   for (let i = 0; i < tags.length; i++) {
     const tag = tags[i];
-
-    const input = `"${tx_id}","${i}","${tag.name}","${tag.value}"\n`;
-
+    const {input} = serializeTags(tx_id, i, tag);
     streams.tags.cache.write(input);
-
     if (storeSnapshot) {
       streams.tags.snapshot.write(input);
     }

--- a/src/database/transaction.database.ts
+++ b/src/database/transaction.database.ts
@@ -1,12 +1,11 @@
 import {config} from 'dotenv';
 import {DataItemJson} from 'arweave-bundles';
 import {pick} from 'lodash';
+import {indices} from '../utility/order.utility';
 import {TransactionType, tagValue} from '../query/transaction.query';
 import {fromB64Url, sha256B64Url} from '../utility/encoding.utility';
 
 config();
-
-export const indices = JSON.parse(process.env.INDICES || '[]');
 
 export interface ANSTransaction {
   id: string;

--- a/src/graphql/query.graphql.ts
+++ b/src/graphql/query.graphql.ts
@@ -1,5 +1,6 @@
 import {config} from 'dotenv';
 import {QueryBuilder} from 'knex';
+import {indices} from '../utility/order.utility';
 import {connection} from '../database/connection.database';
 import {ISO8601DateTimeString} from '../utility/encoding.utility';
 import {TagFilter} from './types';
@@ -12,8 +13,6 @@ export const orderByClauses = {
   HEIGHT_ASC: 'transactions.height ASC NULLS LAST, id ASC',
   HEIGHT_DESC: 'transactions.height DESC NULLS FIRST, id ASC',
 };
-
-export const indices = JSON.parse(process.env.INDICES || '[]');
 
 export interface QueryParams {
   to?: string[];

--- a/src/query/chunk.query.ts
+++ b/src/query/chunk.query.ts
@@ -54,7 +54,7 @@ export async function getChunk(offset: number, retry: boolean = true): Promise<C
     if (retry) {
       return getChunk(offset, false);
     } else {
-      throw new Error(error);
+      throw error;
     }
   }
 }

--- a/src/utility/csv.utility.ts
+++ b/src/utility/csv.utility.ts
@@ -25,20 +25,20 @@ export interface CSVStreams {
 
 export const streams: CSVStreams = {
   block: {
-    snapshot: new WriteStream(),
-    cache: new WriteStream(),
+    snapshot: createWriteStream('snapshot/block.csv', {flags: 'a'}),
+    cache: createWriteStream('cache/block.csv'),
   },
   transaction: {
-    snapshot: new WriteStream(),
-    cache: new WriteStream(),
+    snapshot: createWriteStream('snapshot/transaction.csv', {flags: 'a'}),
+    cache: createWriteStream('cache/transaction.csv'),
   },
   tags: {
-    snapshot: new WriteStream(),
-    cache: new WriteStream(),
+    snapshot: createWriteStream('snapshot/tags.csv', {flags: 'a'}),
+    cache: createWriteStream('cache/tags.csv'),
   },
   rescan: {
-    snapshot: new WriteStream(),
-    cache: new WriteStream(),
+    snapshot: createWriteStream('snapshot/.rescan', {flags: 'a'}),
+    cache: createWriteStream('cache/.rescan', {flags: 'a'}),
   },
 };
 
@@ -82,22 +82,22 @@ export function initStreams() {
   };
 
   if (appendHeaders.block) {
-    streams.block.snapshot.write(blockOrder.join('|'));
+    streams.block.snapshot.write(blockOrder.join('|') + '\n');
   }
 
-  streams.block.cache.write(blockOrder.join('|'));
+  streams.block.cache.write(blockOrder.join('|') + '\n');
 
   if (appendHeaders.transaction) {
-    streams.transaction.snapshot.write(transactionOrder.concat(indices).join('|'));
+    streams.transaction.snapshot.write(transactionOrder.concat(indices).join('|') + '\n');
   }
 
-  streams.transaction.cache.write(transactionOrder.concat(indices).join('|'));
+  streams.transaction.cache.write(transactionOrder.concat(indices).join('|') + '\n');
 
   if (appendHeaders.tags) {
-    streams.tags.snapshot.write(tagOrder.join('|'));
+    streams.tags.snapshot.write(tagOrder.join('|') + '\n');
   }
 
-  streams.tags.cache.write(tagOrder.join('|'));
+  streams.tags.cache.write(tagOrder.join('|') + '\n');
 }
 
 export function resetCacheStreams() {
@@ -105,7 +105,7 @@ export function resetCacheStreams() {
   streams.transaction.cache = createWriteStream('cache/transaction.csv');
   streams.tags.cache = createWriteStream('cache/tags.csv');
 
-  streams.block.cache.write(blockOrder.join('|'));
-  streams.transaction.snapshot.write(transactionOrder.concat(indices).join('|'));
-  streams.tags.cache.write(tagOrder.join('|'));
+  streams.block.cache.write(blockOrder.join('|') + '\n');
+  streams.transaction.snapshot.write(transactionOrder.concat(indices).join('|') + '\n');
+  streams.tags.cache.write(tagOrder.join('|') + '\n');
 }

--- a/src/utility/csv.utility.ts
+++ b/src/utility/csv.utility.ts
@@ -1,0 +1,115 @@
+import { existsSync, WriteStream, createWriteStream } from 'fs';
+
+export const indices = JSON.parse(process.env.INDICES || '[]') as Array<string>;
+export const blockOrder = ["id", "previous_block", "mined_at", "height", "txs", "extended"];
+export const transactionOrder = ["format", "id", "signature", "owner", "owner_address", "target", "reward", "last_tx", "height", "tags", "quantity", "content_type", "data_size", "data_root"];
+export const tagOrder = ["tx_id", "index", "name", "value"];
+
+export interface CSVStreams {
+    block: {
+        snapshot: WriteStream;
+        cache: WriteStream;
+    };
+
+    transaction: {
+        snapshot: WriteStream;
+        cache: WriteStream;
+    };
+
+    tags: {
+        snapshot: WriteStream;
+        cache: WriteStream;
+    };
+
+    rescan: {
+        snapshot: WriteStream;
+        cache: WriteStream;
+    };
+}
+
+export const streams: CSVStreams = {
+    block: {
+        snapshot: new WriteStream(),
+        cache: new WriteStream(),
+    },
+    transaction: {
+        snapshot: new WriteStream(),
+        cache: new WriteStream(),
+    },
+    tags: {
+        snapshot: new WriteStream(),
+        cache: new WriteStream(),
+    },
+    rescan: {
+        snapshot: new WriteStream(),
+        cache: new WriteStream(),
+    },
+}
+
+export function initStreams() {
+    let appendHeaders = {
+        block: false,
+        transaction: false,
+        tags: false,
+    }
+
+    if (!existsSync(`snapshot/block.csv`)) {
+        appendHeaders.block = true;
+    }
+
+    if (!existsSync(`snapshot/transaction.csv`)) {
+        appendHeaders.transaction = true;
+    }
+
+    if (!existsSync(`snapshot/tags.csv`)) {
+        appendHeaders.tags = true;
+    }
+
+    streams.block = {
+        snapshot: createWriteStream('snapshot/block.csv', {flags: 'a'}),
+        cache: createWriteStream('cache/block.csv'),
+    };
+
+    streams.transaction = {
+        snapshot: createWriteStream('snapshot/transaction.csv', {flags: 'a'}),
+        cache: createWriteStream('cache/transaction.csv'),
+    };
+    
+    streams.tags = {
+        snapshot: createWriteStream('snapshot/tags.csv', {flags: 'a'}),
+        cache: createWriteStream('cache/tags.csv'),
+    };
+
+    streams.rescan = {
+        snapshot: createWriteStream('snapshot/.rescan', {flags: 'a'}),
+        cache: createWriteStream('cache/.rescan', {flags: 'a'}),
+    };
+
+    if (appendHeaders.block) {
+        streams.block.snapshot.write(blockOrder.join(`|`));
+    }
+    
+    streams.block.cache.write(blockOrder.join(`|`));
+
+    if (appendHeaders.transaction) {
+        streams.transaction.snapshot.write(transactionOrder.concat(indices).join(`|`));
+    }
+
+    streams.transaction.cache.write(transactionOrder.concat(indices).join(`|`));
+
+    if (appendHeaders.tags) {
+        streams.tags.snapshot.write(tagOrder.join(`|`));
+    }
+    
+    streams.tags.cache.write(tagOrder.join(`|`));
+}
+
+export function resetCacheStreams() {
+    streams.block.cache = createWriteStream('cache/block.csv');
+    streams.transaction.cache = createWriteStream('cache/transaction.csv');
+    streams.tags.cache = createWriteStream('cache/tags.csv');
+
+    streams.block.cache.write(blockOrder.join(`|`));
+    streams.transaction.snapshot.write(transactionOrder.concat(indices).join(`|`));
+    streams.tags.cache.write(tagOrder.join(`|`));
+}

--- a/src/utility/csv.utility.ts
+++ b/src/utility/csv.utility.ts
@@ -1,9 +1,5 @@
-import { existsSync, WriteStream, createWriteStream } from 'fs';
-
-export const indices = JSON.parse(process.env.INDICES || '[]') as Array<string>;
-export const blockOrder = ["id", "previous_block", "mined_at", "height", "txs", "extended"];
-export const transactionOrder = ["format", "id", "signature", "owner", "owner_address", "target", "reward", "last_tx", "height", "tags", "quantity", "content_type", "data_size", "data_root"];
-export const tagOrder = ["tx_id", "index", "name", "value"];
+import {existsSync, WriteStream, createWriteStream} from 'fs';
+import {indices, blockOrder, transactionOrder, tagOrder} from './order.utility';
 
 export interface CSVStreams {
     block: {
@@ -28,88 +24,88 @@ export interface CSVStreams {
 }
 
 export const streams: CSVStreams = {
-    block: {
-        snapshot: new WriteStream(),
-        cache: new WriteStream(),
-    },
-    transaction: {
-        snapshot: new WriteStream(),
-        cache: new WriteStream(),
-    },
-    tags: {
-        snapshot: new WriteStream(),
-        cache: new WriteStream(),
-    },
-    rescan: {
-        snapshot: new WriteStream(),
-        cache: new WriteStream(),
-    },
-}
+  block: {
+    snapshot: new WriteStream(),
+    cache: new WriteStream(),
+  },
+  transaction: {
+    snapshot: new WriteStream(),
+    cache: new WriteStream(),
+  },
+  tags: {
+    snapshot: new WriteStream(),
+    cache: new WriteStream(),
+  },
+  rescan: {
+    snapshot: new WriteStream(),
+    cache: new WriteStream(),
+  },
+};
 
 export function initStreams() {
-    let appendHeaders = {
-        block: false,
-        transaction: false,
-        tags: false,
-    }
+  const appendHeaders = {
+    block: false,
+    transaction: false,
+    tags: false,
+  };
 
-    if (!existsSync(`snapshot/block.csv`)) {
-        appendHeaders.block = true;
-    }
+  if (!existsSync('snapshot/block.csv')) {
+    appendHeaders.block = true;
+  }
 
-    if (!existsSync(`snapshot/transaction.csv`)) {
-        appendHeaders.transaction = true;
-    }
+  if (!existsSync('snapshot/transaction.csv')) {
+    appendHeaders.transaction = true;
+  }
 
-    if (!existsSync(`snapshot/tags.csv`)) {
-        appendHeaders.tags = true;
-    }
+  if (!existsSync('snapshot/tags.csv')) {
+    appendHeaders.tags = true;
+  }
 
-    streams.block = {
-        snapshot: createWriteStream('snapshot/block.csv', {flags: 'a'}),
-        cache: createWriteStream('cache/block.csv'),
-    };
+  streams.block = {
+    snapshot: createWriteStream('snapshot/block.csv', {flags: 'a'}),
+    cache: createWriteStream('cache/block.csv'),
+  };
 
-    streams.transaction = {
-        snapshot: createWriteStream('snapshot/transaction.csv', {flags: 'a'}),
-        cache: createWriteStream('cache/transaction.csv'),
-    };
-    
-    streams.tags = {
-        snapshot: createWriteStream('snapshot/tags.csv', {flags: 'a'}),
-        cache: createWriteStream('cache/tags.csv'),
-    };
+  streams.transaction = {
+    snapshot: createWriteStream('snapshot/transaction.csv', {flags: 'a'}),
+    cache: createWriteStream('cache/transaction.csv'),
+  };
 
-    streams.rescan = {
-        snapshot: createWriteStream('snapshot/.rescan', {flags: 'a'}),
-        cache: createWriteStream('cache/.rescan', {flags: 'a'}),
-    };
+  streams.tags = {
+    snapshot: createWriteStream('snapshot/tags.csv', {flags: 'a'}),
+    cache: createWriteStream('cache/tags.csv'),
+  };
 
-    if (appendHeaders.block) {
-        streams.block.snapshot.write(blockOrder.join(`|`));
-    }
-    
-    streams.block.cache.write(blockOrder.join(`|`));
+  streams.rescan = {
+    snapshot: createWriteStream('snapshot/.rescan', {flags: 'a'}),
+    cache: createWriteStream('cache/.rescan', {flags: 'a'}),
+  };
 
-    if (appendHeaders.transaction) {
-        streams.transaction.snapshot.write(transactionOrder.concat(indices).join(`|`));
-    }
+  if (appendHeaders.block) {
+    streams.block.snapshot.write(blockOrder.join('|'));
+  }
 
-    streams.transaction.cache.write(transactionOrder.concat(indices).join(`|`));
+  streams.block.cache.write(blockOrder.join('|'));
 
-    if (appendHeaders.tags) {
-        streams.tags.snapshot.write(tagOrder.join(`|`));
-    }
-    
-    streams.tags.cache.write(tagOrder.join(`|`));
+  if (appendHeaders.transaction) {
+    streams.transaction.snapshot.write(transactionOrder.concat(indices).join('|'));
+  }
+
+  streams.transaction.cache.write(transactionOrder.concat(indices).join('|'));
+
+  if (appendHeaders.tags) {
+    streams.tags.snapshot.write(tagOrder.join('|'));
+  }
+
+  streams.tags.cache.write(tagOrder.join('|'));
 }
 
 export function resetCacheStreams() {
-    streams.block.cache = createWriteStream('cache/block.csv');
-    streams.transaction.cache = createWriteStream('cache/transaction.csv');
-    streams.tags.cache = createWriteStream('cache/tags.csv');
+  streams.block.cache = createWriteStream('cache/block.csv');
+  streams.transaction.cache = createWriteStream('cache/transaction.csv');
+  streams.tags.cache = createWriteStream('cache/tags.csv');
 
-    streams.block.cache.write(blockOrder.join(`|`));
-    streams.transaction.snapshot.write(transactionOrder.concat(indices).join(`|`));
-    streams.tags.cache.write(tagOrder.join(`|`));
+  streams.block.cache.write(blockOrder.join('|'));
+  streams.transaction.snapshot.write(transactionOrder.concat(indices).join('|'));
+  streams.tags.cache.write(tagOrder.join('|'));
 }

--- a/src/utility/height.utility.ts
+++ b/src/utility/height.utility.ts
@@ -1,0 +1,16 @@
+import {connection} from '../database/connection.database';
+
+export async function lastBlock() {
+  const result = await connection
+      .queryBuilder()
+      .select('height')
+      .from('blocks')
+      .orderBy('height', 'desc')
+      .limit(1);
+
+  if (result.length > 0) {
+    return result[0].height;
+  } else {
+    return 0;
+  }
+}

--- a/src/utility/order.utility.ts
+++ b/src/utility/order.utility.ts
@@ -1,0 +1,4 @@
+export const indices = JSON.parse(process.env.INDICES || '[]') as Array<string>;
+export const blockOrder = ['id', 'previous_block', 'mined_at', 'height', 'txs', 'extended'];
+export const transactionOrder = ['format', 'id', 'signature', 'owner', 'owner_address', 'target', 'reward', 'last_tx', 'height', 'tags', 'quantity', 'content_type', 'data_size', 'data_root'];
+export const tagOrder = ['tx_id', 'index', 'name', 'value'];

--- a/src/utility/serialize.utility.ts
+++ b/src/utility/serialize.utility.ts
@@ -1,0 +1,63 @@
+import {DataItemJson} from 'arweave-bundles';
+import {indices} from './order.utility';
+import {BlockType} from '../query/block.query';
+import {TransactionType, Tag} from '../query/transaction.query';
+import {formatBlock} from '../database/block.database';
+import {formatTransaction, transactionFields, formatAnsTransaction} from '../database/transaction.database';
+
+export const delimiter = '|';
+
+export function serializeBlock(block: BlockType, height: number) {
+  const formattedBlock = formatBlock(block);
+  const values = [`"${formattedBlock.id}"`, `"${formattedBlock.previous_block}"`, `"${formattedBlock.mined_at}"`, `"${formattedBlock.height}"`, `"${formattedBlock.txs.replace(/"/g, '\\"')}"`, `"${formattedBlock.extended.replace(/"/g, '\\"')}"`];
+
+  const input = `${values.join(delimiter)}\n`;
+
+  return {
+    formattedBlock,
+    input,
+  };
+}
+
+export function serializeTransaction(tx: TransactionType, height: number) {
+  const formattedTransaction = formatTransaction(tx);
+  const preservedTags = JSON.parse(formattedTransaction.tags) as Array<Tag>;
+  formattedTransaction.tags = `${formattedTransaction.tags.replace(/"/g, '\\"')}`;
+
+  const values = transactionFields
+      .map((field) => `"${field === 'height' ? height : formattedTransaction[field] ? formattedTransaction[field] : ''}"`)
+      .concat(indices.map((ifield) => `"${formattedTransaction[ifield] ? formattedTransaction[ifield] : ''}"`));
+
+  const input = `${values.join(delimiter)}\n`;
+
+  return {
+    formattedTransaction,
+    preservedTags,
+    input,
+  };
+}
+
+export function serializeAnsTransaction(tx: DataItemJson, height: number) {
+  const formattedAnsTransaction = formatAnsTransaction(tx);
+  formattedAnsTransaction.tags = `${formattedAnsTransaction.tags.replace(/"/g, '\\"')}`;
+
+  const ansTags = tx.tags;
+
+  const values = transactionFields
+      .map((field) => `"${field === 'height' ? height : formattedAnsTransaction[field] ? formattedAnsTransaction[field] : ''}"`)
+      .concat(indices.map((ifield) => `"${formattedAnsTransaction[ifield] ? formattedAnsTransaction[ifield] : ''}"`));
+
+  const input = `${values.join(delimiter)}\n`;
+
+  return {
+    formattedAnsTransaction,
+    ansTags,
+    input,
+  };
+}
+
+export function serializeTags(tx_id: string, index: number, tag: Tag) {
+  const values = [`"${tx_id}"`, `"${index}"`, `"${tag.name}"`, `"${tag.value}"`];
+  const input = `${values.join(delimiter)}\n`;
+  return {input};
+}


### PR DESCRIPTION
## CHANGELOG

- Sync state is based on highest block height in the database instead of `.snapshot` files.

- Importing a snapshot utilizes absolute paths with the `.env` file. Specify by filling in:

```config
BLOCK_PATH=
TRANSACTION_PATH=
TAGS_PATH=
```

- Updated documentation in regards to pulling snapshots in `docs/SNAPSHOT.md`

- Caches and Snapshots use `|` delimiter instead of `,` to prevent potential errors.

- Caches and Snapshots now have a header and encoding for imports are updated to use headers.

- Various refactors have been done to be more `DRY`.