### PR TITLE
aws rds compatability: make the need for `sudo` redundant

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "git@github.com:ArweaveTeam/gateway.git",
   "author": "Arweave <hello@arweave.org>",
   "license": "MIT",
+  "prettier": {
+    "singleQuote": true
+  },
   "scripts": {
     "dev:test": "npm run dev:build && nyc mocha dist/test dist/test/**/*.js",
     "dev:codecov": "nyc report --reporter=text-lcov | codecov --pipe --token=cea7a229-8289-4a7c-9dc6-4fb694978cb2",
@@ -76,6 +79,7 @@
     "@types/node": "^14.14.22",
     "@types/node-cron": "^2.0.3",
     "@types/pg": "^7.14.11",
+    "@types/pg-copy-streams": "^1.2.1",
     "@types/progress": "^2.0.3",
     "@types/shortid": "^0.0.29",
     "@types/superagent": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "morgan": "^1.10.0",
     "node-cron": "^2.0.3",
     "pg": "^8.5.1",
+    "pg-copy-streams": "^5.1.1",
     "progress": "^2.0.3",
     "rfc4648": "^1.4.0",
     "shortid": "^2.2.16",

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -1,7 +1,9 @@
+import fs from 'fs';
 import {config} from 'dotenv';
 import {indices} from '../utility/order.utility';
 import {connection} from '../database/connection.database';
 import {transactionFields} from '../database/transaction.database';
+import {from as copyFrom} from 'pg-copy-streams';
 
 config();
 
@@ -9,9 +11,10 @@ export async function importBlocks(path: string) {
   return new Promise(async (resolve, reject) => {
     try {
       const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("height"))';
-      await connection.raw(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM '${path}' WITH ${encoding}`);
-
-      return resolve(true);
+      const stream = connection.query(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`);
+      const fileStream = fs.createReadStream(path);
+      fileStream.on('error', reject);
+      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
     } catch (error) {
       return reject(error);
     }
@@ -26,9 +29,11 @@ export async function importTransactions(path: string) {
           .map((field) => `"${field}"`);
 
       const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
-      await connection.raw(`COPY transactions (${fields.join(',')}) FROM '${path}' WITH ${encoding}`);
+      const stream = connection.query(`COPY transactions (${fields.join(',')}) FROM STDIN WITH ${encoding}`);
+      const fileStream = fs.createReadStream(path);
+      fileStream.on('error', reject);
+      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
 
-      return resolve(true);
     } catch (error) {
       return reject(error);
     }
@@ -39,9 +44,11 @@ export async function importTags(path: string) {
   return new Promise(async (resolve, reject) => {
     try {
       const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL(index))';
-      await connection.raw(`COPY tags ("tx_id", "index", "name", "value") FROM '${path}' WITH ${encoding}`);
+      const stream = connection.query(`COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`);
+      const fileStream = fs.createReadStream(path);
+      fileStream.on('error', reject);
+      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
 
-      return resolve(true);
     } catch (error) {
       return reject(error);
     }

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -28,9 +28,9 @@ export async function importBlocks(path: string) {
           client.release();
           resolve(true);
         })
-        .on("error", (err) => {
+        .on("error", (err: unknown) => {
           client.release();
-          reject(err);
+          reject(new String(err));
         });
     } catch (error) {
       return reject(error);
@@ -65,9 +65,9 @@ export async function importTransactions(path: string) {
           client.release();
           resolve(true);
         })
-        .on("error", (err) => {
+        .on("error", (err: unknown) => {
           client.release();
-          reject(err);
+          reject(new String(err));
         });
     } catch (error) {
       return reject(error);
@@ -98,9 +98,9 @@ export async function importTags(path: string) {
           client.release();
           resolve(true);
         })
-        .on("error", (err) => {
+        .on("error", (err: unknown) => {
           client.release();
-          reject(err);
+          reject(new String(err));
         });
     } catch (error) {
       return reject(error);

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -1,20 +1,37 @@
-import fs from 'fs';
-import {config} from 'dotenv';
-import {indices} from '../utility/order.utility';
-import {connection} from '../database/connection.database';
-import {transactionFields} from '../database/transaction.database';
-import {from as copyFrom} from 'pg-copy-streams';
+import fs from "fs";
+import { PoolClient } from "pg";
+import { config } from "dotenv";
+import { indices } from "../utility/order.utility";
+import { pgConnection } from "../database/connection.database";
+import { transactionFields } from "../database/transaction.database";
+import { from as copyFrom } from "pg-copy-streams";
 
 config();
 
 export async function importBlocks(path: string) {
   return new Promise(async (resolve, reject) => {
+    let client: PoolClient;
     try {
-      const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("height"))';
-      const stream = connection.query(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`);
+      client = await pgConnection.connect();
+      const encoding =
+        "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(\"height\"))";
+      const stream = client.query(
+        copyFrom(
+          `COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`
+        )
+      );
       const fileStream = fs.createReadStream(path);
-      fileStream.on('error', reject);
-      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
+      fileStream.on("error", reject);
+      fileStream
+        .pipe(stream)
+        .on("finish", () => {
+          client.release();
+          resolve(true);
+        })
+        .on("error", (err) => {
+          client.release();
+          reject(err);
+        });
     } catch (error) {
       return reject(error);
     }
@@ -23,17 +40,35 @@ export async function importBlocks(path: string) {
 
 export async function importTransactions(path: string) {
   return new Promise(async (resolve, reject) => {
+    let client: PoolClient;
     try {
+      client = await pgConnection.connect();
       const fields = transactionFields
-          .concat(indices)
-          .map((field) => `"${field}"`);
+        .concat(indices)
+        .map((field) => `"${field}"`);
 
-      const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
-      const stream = connection.query(`COPY transactions (${fields.join(',')}) FROM STDIN WITH ${encoding}`);
+      const encoding =
+        '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
+      const stream = client.query(
+        copyFrom(
+          `COPY transactions (${fields.join(",")}) FROM STDIN WITH ${encoding}`
+        )
+      );
       const fileStream = fs.createReadStream(path);
-      fileStream.on('error', reject);
-      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
-
+      fileStream.on("error", () => {
+        client.release();
+        reject();
+      });
+      fileStream
+        .pipe(stream)
+        .on("finish", () => {
+          client.release();
+          resolve(true);
+        })
+        .on("error", (err) => {
+          client.release();
+          reject(err);
+        });
     } catch (error) {
       return reject(error);
     }
@@ -42,13 +77,31 @@ export async function importTransactions(path: string) {
 
 export async function importTags(path: string) {
   return new Promise(async (resolve, reject) => {
+    let client: PoolClient;
     try {
-      const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL(index))';
-      const stream = connection.query(`COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`);
+      client = await pgConnection.connect();
+      const encoding =
+        "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(index))";
+      const stream = client.query(
+        copyFrom(
+          `COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`
+        )
+      );
       const fileStream = fs.createReadStream(path);
-      fileStream.on('error', reject);
-      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
-
+      fileStream.on("error", () => {
+        client.release();
+        reject();
+      });
+      fileStream
+        .pipe(stream)
+        .on("finish", () => {
+          client.release();
+          resolve(true);
+        })
+        .on("error", (err) => {
+          client.release();
+          reject(err);
+        });
     } catch (error) {
       return reject(error);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6082,6 +6082,11 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
+obuf@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
+  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -6384,6 +6389,13 @@ pg-connection-string@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-copy-streams@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/pg-copy-streams/-/pg-copy-streams-5.1.1.tgz#012f48c332cc31490aa0b5330bc571795963230f"
+  integrity sha512-ieW6JuiIo/4WQ7n+Wevr9zYvpM1AwUs6EwNCCA0VgKZ6ZQ7Y9k3IW00vqc6svX9FtENhbaTbLN7MxekraCrbfg==
+  dependencies:
+    obuf "^1.1.2"
 
 pg-int8@1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,6 +1340,23 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pg-copy-streams@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/pg-copy-streams/-/pg-copy-streams-1.2.1.tgz#f598cee10b59c20c8f155358bd99a6c438c42aae"
+  integrity sha512-7gsqXeYd4CypX4ZslvOhCuquL6Uo6B/ariCxw67fw6k+YL/Y1XncraDN/7qVlbM5WE5tmhxPxmacufrZ1/iloQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/pg" "*"
+
+"@types/pg@*":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.1.tgz#099450b8dc977e8197a44f5229cedef95c8747f9"
+  integrity sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/pg@^7.14.11":
   version "7.14.11"
   resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.14.11.tgz#daf5555504a1f7af4263df265d91f140fece52e3"
@@ -6407,7 +6424,7 @@ pg-pool@^3.3.0:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.3.0.tgz#12d5c7f65ea18a6e99ca9811bd18129071e562fc"
   integrity sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==
 
-pg-protocol@^1.2.0, pg-protocol@^1.5.0:
+pg-protocol@*, pg-protocol@^1.2.0, pg-protocol@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
   integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==


### PR DESCRIPTION
As I was trying to get the gateway running on aws rds, I hit into the caveat of the copy mechanism with postgresql on amazon aws. Which is that copy works as long as you don't copy from file to file. Only prompt copy or stream is allowed. By streaming the text trough nodejs we can bypass this requirement and will open the door to aws support.