### PR TITLE
remove unneccecary async try-catches

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "git@github.com:ArweaveTeam/gateway.git",
   "author": "Arweave <hello@arweave.org>",
   "license": "MIT",
+  "prettier": {
+    "singleQuote": true
+  },
   "scripts": {
     "dev:test": "npm run dev:build && nyc mocha dist/test dist/test/**/*.js",
     "dev:codecov": "nyc report --reporter=text-lcov | codecov --pipe --token=cea7a229-8289-4a7c-9dc6-4fb694978cb2",
@@ -76,6 +79,7 @@
     "@types/node": "^14.14.22",
     "@types/node-cron": "^2.0.3",
     "@types/pg": "^7.14.11",
+    "@types/pg-copy-streams": "^1.2.1",
     "@types/progress": "^2.0.3",
     "@types/shortid": "^0.0.29",
     "@types/superagent": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "morgan": "^1.10.0",
     "node-cron": "^2.0.3",
     "pg": "^8.5.1",
+    "pg-copy-streams": "^5.1.1",
     "progress": "^2.0.3",
     "rfc4648": "^1.4.0",
     "shortid": "^2.2.16",

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -1,7 +1,9 @@
+import fs from 'fs';
 import {config} from 'dotenv';
 import {indices} from '../utility/order.utility';
 import {connection} from '../database/connection.database';
 import {transactionFields} from '../database/transaction.database';
+import {from as copyFrom} from 'pg-copy-streams';
 
 config();
 
@@ -9,9 +11,10 @@ export async function importBlocks(path: string) {
   return new Promise(async (resolve, reject) => {
     try {
       const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("height"))';
-      await connection.raw(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM '${path}' WITH ${encoding}`);
-
-      return resolve(true);
+      const stream = connection.query(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`);
+      const fileStream = fs.createReadStream(path);
+      fileStream.on('error', reject);
+      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
     } catch (error) {
       return reject(error);
     }
@@ -26,9 +29,11 @@ export async function importTransactions(path: string) {
           .map((field) => `"${field}"`);
 
       const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
-      await connection.raw(`COPY transactions (${fields.join(',')}) FROM '${path}' WITH ${encoding}`);
+      const stream = connection.query(`COPY transactions (${fields.join(',')}) FROM STDIN WITH ${encoding}`);
+      const fileStream = fs.createReadStream(path);
+      fileStream.on('error', reject);
+      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
 
-      return resolve(true);
     } catch (error) {
       return reject(error);
     }
@@ -39,9 +44,11 @@ export async function importTags(path: string) {
   return new Promise(async (resolve, reject) => {
     try {
       const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL(index))';
-      await connection.raw(`COPY tags ("tx_id", "index", "name", "value") FROM '${path}' WITH ${encoding}`);
+      const stream = connection.query(`COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`);
+      const fileStream = fs.createReadStream(path);
+      fileStream.on('error', reject);
+      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
 
-      return resolve(true);
     } catch (error) {
       return reject(error);
     }

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -1,109 +1,94 @@
-import fs from "fs";
-import { PoolClient } from "pg";
-import { config } from "dotenv";
-import { indices } from "../utility/order.utility";
-import { pgConnection } from "../database/connection.database";
-import { transactionFields } from "../database/transaction.database";
-import { from as copyFrom } from "pg-copy-streams";
+import fs from 'fs';
+import { PoolClient } from 'pg';
+import { config } from 'dotenv';
+import { indices } from '../utility/order.utility';
+import { pgConnection } from '../database/connection.database';
+import { transactionFields } from '../database/transaction.database';
+import { from as copyFrom } from 'pg-copy-streams';
 
 config();
 
-export async function importBlocks(path: string) {
+export function importBlocks(path: string) {
   return new Promise(async (resolve, reject) => {
-    let client: PoolClient;
-    try {
-      client = await pgConnection.connect();
-      const encoding =
-        "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(\"height\"))";
-      const stream = client.query(
-        copyFrom(
-          `COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`
-        )
-      );
-      const fileStream = fs.createReadStream(path);
-      fileStream.on("error", reject);
-      fileStream
-        .pipe(stream)
-        .on("finish", () => {
-          client.release();
-          resolve(true);
-        })
-        .on("error", (err: unknown) => {
-          client.release();
-          reject(new String(err));
-        });
-    } catch (error) {
-      return reject(error);
-    }
+    const client: PoolClient = await pgConnection.connect();
+    const encoding =
+      "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(\"height\"))";
+    const stream = client.query(
+      copyFrom(
+        `COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`
+      )
+    );
+    const fileStream = fs.createReadStream(path);
+    fileStream.on('error', reject);
+    fileStream
+      .pipe(stream)
+      .on('finish', () => {
+        client.release();
+        resolve(true);
+      })
+      .on('error', (err: unknown) => {
+        client.release();
+        reject(new String(err));
+      });
   });
 }
 
-export async function importTransactions(path: string) {
+export function importTransactions(path: string) {
   return new Promise(async (resolve, reject) => {
-    let client: PoolClient;
-    try {
-      client = await pgConnection.connect();
-      const fields = transactionFields
-        .concat(indices)
-        .map((field) => `"${field}"`);
+    const client: PoolClient = await pgConnection.connect();
+    const fields = transactionFields
+      .concat(indices)
+      .map((field) => `"${field}"`);
 
-      const encoding =
-        '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
-      const stream = client.query(
-        copyFrom(
-          `COPY transactions (${fields.join(",")}) FROM STDIN WITH ${encoding}`
-        )
-      );
-      const fileStream = fs.createReadStream(path);
-      fileStream.on("error", () => {
+    const encoding =
+      '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
+    const stream = client.query(
+      copyFrom(
+        `COPY transactions (${fields.join(',')}) FROM STDIN WITH ${encoding}`
+      )
+    );
+    const fileStream = fs.createReadStream(path);
+    fileStream.on('error', () => {
+      client.release();
+      reject();
+    });
+    fileStream
+      .pipe(stream)
+      .on('finish', () => {
         client.release();
-        reject();
+        resolve(true);
+      })
+      .on('error', (err: unknown) => {
+        client.release();
+        reject(new String(err));
       });
-      fileStream
-        .pipe(stream)
-        .on("finish", () => {
-          client.release();
-          resolve(true);
-        })
-        .on("error", (err: unknown) => {
-          client.release();
-          reject(new String(err));
-        });
-    } catch (error) {
-      return reject(error);
-    }
   });
 }
 
-export async function importTags(path: string) {
+export function importTags(path: string) {
   return new Promise(async (resolve, reject) => {
-    let client: PoolClient;
-    try {
-      client = await pgConnection.connect();
-      const encoding =
-        "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(index))";
-      const stream = client.query(
-        copyFrom(
-          `COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`
-        )
-      );
-      const fileStream = fs.createReadStream(path);
-      fileStream.on("error", () => {
+    const client: PoolClient = await pgConnection.connect();
+    const encoding =
+      "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(index))";
+    const stream = client.query(
+      copyFrom(
+        `COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`
+      )
+    );
+    const fileStream = fs.createReadStream(path);
+    fileStream.on('error', () => {
+      client.release();
+      reject();
+    });
+    fileStream
+      .pipe(stream)
+      .on('finish', () => {
         client.release();
-        reject();
+        resolve(true);
+      })
+      .on('error', (err: unknown) => {
+        client.release();
+        reject(new String(err));
       });
-      fileStream
-        .pipe(stream)
-        .on("finish", () => {
-          client.release();
-          resolve(true);
-        })
-        .on("error", (err: unknown) => {
-          client.release();
-          reject(new String(err));
-        });
-    } catch (error) {
-      return reject(error);
-    }
   });
 }

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -28,9 +28,9 @@ export async function importBlocks(path: string) {
           client.release();
           resolve(true);
         })
-        .on("error", (err) => {
+        .on("error", (err: unknown) => {
           client.release();
-          reject(err);
+          reject(new String(err));
         });
     } catch (error) {
       return reject(error);
@@ -65,9 +65,9 @@ export async function importTransactions(path: string) {
           client.release();
           resolve(true);
         })
-        .on("error", (err) => {
+        .on("error", (err: unknown) => {
           client.release();
-          reject(err);
+          reject(new String(err));
         });
     } catch (error) {
       return reject(error);
@@ -98,9 +98,9 @@ export async function importTags(path: string) {
           client.release();
           resolve(true);
         })
-        .on("error", (err) => {
+        .on("error", (err: unknown) => {
           client.release();
-          reject(err);
+          reject(new String(err));
         });
     } catch (error) {
       return reject(error);

--- a/src/database/import.database.ts
+++ b/src/database/import.database.ts
@@ -1,20 +1,37 @@
-import fs from 'fs';
-import {config} from 'dotenv';
-import {indices} from '../utility/order.utility';
-import {connection} from '../database/connection.database';
-import {transactionFields} from '../database/transaction.database';
-import {from as copyFrom} from 'pg-copy-streams';
+import fs from "fs";
+import { PoolClient } from "pg";
+import { config } from "dotenv";
+import { indices } from "../utility/order.utility";
+import { pgConnection } from "../database/connection.database";
+import { transactionFields } from "../database/transaction.database";
+import { from as copyFrom } from "pg-copy-streams";
 
 config();
 
 export async function importBlocks(path: string) {
   return new Promise(async (resolve, reject) => {
+    let client: PoolClient;
     try {
-      const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("height"))';
-      const stream = connection.query(`COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`);
+      client = await pgConnection.connect();
+      const encoding =
+        "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(\"height\"))";
+      const stream = client.query(
+        copyFrom(
+          `COPY blocks ("id", "previous_block", "mined_at", "height", "txs", "extended") FROM STDIN WITH ${encoding}`
+        )
+      );
       const fileStream = fs.createReadStream(path);
-      fileStream.on('error', reject);
-      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
+      fileStream.on("error", reject);
+      fileStream
+        .pipe(stream)
+        .on("finish", () => {
+          client.release();
+          resolve(true);
+        })
+        .on("error", (err) => {
+          client.release();
+          reject(err);
+        });
     } catch (error) {
       return reject(error);
     }
@@ -23,17 +40,35 @@ export async function importBlocks(path: string) {
 
 export async function importTransactions(path: string) {
   return new Promise(async (resolve, reject) => {
+    let client: PoolClient;
     try {
+      client = await pgConnection.connect();
       const fields = transactionFields
-          .concat(indices)
-          .map((field) => `"${field}"`);
+        .concat(indices)
+        .map((field) => `"${field}"`);
 
-      const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
-      const stream = connection.query(`COPY transactions (${fields.join(',')}) FROM STDIN WITH ${encoding}`);
+      const encoding =
+        '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL("format", "height", "data_size"))';
+      const stream = client.query(
+        copyFrom(
+          `COPY transactions (${fields.join(",")}) FROM STDIN WITH ${encoding}`
+        )
+      );
       const fileStream = fs.createReadStream(path);
-      fileStream.on('error', reject);
-      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
-
+      fileStream.on("error", () => {
+        client.release();
+        reject();
+      });
+      fileStream
+        .pipe(stream)
+        .on("finish", () => {
+          client.release();
+          resolve(true);
+        })
+        .on("error", (err) => {
+          client.release();
+          reject(err);
+        });
     } catch (error) {
       return reject(error);
     }
@@ -42,13 +77,31 @@ export async function importTransactions(path: string) {
 
 export async function importTags(path: string) {
   return new Promise(async (resolve, reject) => {
+    let client: PoolClient;
     try {
-      const encoding = '(FORMAT CSV, HEADER, ESCAPE \'\\\', DELIMITER \'|\', FORCE_NULL(index))';
-      const stream = connection.query(`COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`);
+      client = await pgConnection.connect();
+      const encoding =
+        "(FORMAT CSV, HEADER, ESCAPE '\\', DELIMITER '|', FORCE_NULL(index))";
+      const stream = client.query(
+        copyFrom(
+          `COPY tags ("tx_id", "index", "name", "value") FROM STDIN WITH ${encoding}`
+        )
+      );
       const fileStream = fs.createReadStream(path);
-      fileStream.on('error', reject);
-      fileStream.pipe(stream).on('finish', resolve).on('error', reject);
-
+      fileStream.on("error", () => {
+        client.release();
+        reject();
+      });
+      fileStream
+        .pipe(stream)
+        .on("finish", () => {
+          client.release();
+          resolve(true);
+        })
+        .on("error", (err) => {
+          client.release();
+          reject(err);
+        });
     } catch (error) {
       return reject(error);
     }

--- a/src/database/sync.database.ts
+++ b/src/database/sync.database.ts
@@ -1,21 +1,34 @@
 import ProgressBar from 'progress';
-import {DataItemJson} from 'arweave-bundles';
-import {config} from 'dotenv';
-import {getLastBlock} from '../utility/height.utility';
-import {serializeBlock, serializeTransaction, serializeAnsTransaction, serializeTags} from '../utility/serialize.utility';
-import {streams, initStreams, resetCacheStreams} from '../utility/csv.utility';
-import {log} from '../utility/log.utility';
-import {ansBundles} from '../utility/ans.utility';
-import {mkdir} from '../utility/file.utility';
-import {sleep} from '../utility/sleep.utility';
-import {TestSuite} from '../utility/mocha.utility';
-import {getNodeInfo} from '../query/node.query';
-import {block} from '../query/block.query';
-import {transaction, tagValue, Tag} from '../query/transaction.query';
-import {getDataFromChunks} from '../query/node.query';
-import {importBlocks, importTransactions, importTags} from './import.database';
-import {DatabaseTag} from './transaction.database';
-import {cacheANSEntries} from '../caching/ans.entry.caching';
+import { DataItemJson } from 'arweave-bundles';
+import { config } from 'dotenv';
+import { getLastBlock } from '../utility/height.utility';
+import {
+  serializeBlock,
+  serializeTransaction,
+  serializeAnsTransaction,
+  serializeTags,
+} from '../utility/serialize.utility';
+import {
+  streams,
+  initStreams,
+  resetCacheStreams,
+} from '../utility/csv.utility';
+import { log } from '../utility/log.utility';
+import { ansBundles } from '../utility/ans.utility';
+import { mkdir } from '../utility/file.utility';
+import { sleep } from '../utility/sleep.utility';
+import { TestSuite } from '../utility/mocha.utility';
+import { getNodeInfo } from '../query/node.query';
+import { block } from '../query/block.query';
+import { transaction, tagValue, Tag } from '../query/transaction.query';
+import { getDataFromChunks } from '../query/node.query';
+import {
+  importBlocks,
+  importTransactions,
+  importTags,
+} from './import.database';
+import { DatabaseTag } from './transaction.database';
+import { cacheANSEntries } from '../caching/ans.entry.caching';
 
 config();
 mkdir('snapshot');
@@ -32,14 +45,11 @@ export let currentHeight = 0;
 export let timer = setTimeout(() => {}, 0);
 
 export function configureSyncBar(start: number, end: number) {
-  bar = new ProgressBar(
-      ':current/:total blocks synced [:bar] :percent :etas',
-      {
-        complete: '|',
-        incomplete: ' ',
-        total: end - start,
-      },
-  );
+  bar = new ProgressBar(':current/:total blocks synced [:bar] :percent :etas', {
+    complete: '|',
+    incomplete: ' ',
+    total: end - start,
+  });
 }
 
 export async function startSync() {
@@ -47,7 +57,9 @@ export async function startSync() {
   currentHeight = startHeight;
 
   if (parallelization > 0) {
-    log.info(`[database] starting sync, parallelization is set to ${parallelization}`);
+    log.info(
+      `[database] starting sync, parallelization is set to ${parallelization}`
+    );
     if (storeSnapshot) {
       log.info('[snapshot] also writing new blocks to the snapshot folder');
     }
@@ -60,7 +72,9 @@ export async function startSync() {
       configureSyncBar(startHeight, nodeInfo.height);
       topHeight = nodeInfo.height;
 
-      log.info(`[database] database is currently at height ${startHeight}, resuming sync to ${topHeight}`);
+      log.info(
+        `[database] database is currently at height ${startHeight}, resuming sync to ${topHeight}`
+      );
 
       bar.tick();
       await parallelize(startHeight + 1);
@@ -89,7 +103,9 @@ export async function parallelize(height: number) {
     await sleep(30000);
     const nodeInfo = await getNodeInfo();
     if (nodeInfo.height > topHeight) {
-      log.info(`[database] updated height from ${topHeight} to ${nodeInfo.height} syncing new blocks`);
+      log.info(
+        `[database] updated height from ${topHeight} to ${nodeInfo.height} syncing new blocks`
+      );
       topHeight = nodeInfo.height;
     }
 
@@ -108,24 +124,29 @@ export async function parallelize(height: number) {
     try {
       await importBlocks(`${process.cwd()}/cache/block.csv`);
     } catch (error) {
-      log.error('[sync] importing new blocks failed most likely due to it already being in the DB');
+      log.error(
+        '[sync] importing new blocks failed most likely due to it already being in the DB'
+      );
       log.error(error);
     }
 
     try {
       await importTransactions(`${process.cwd()}/cache/transaction.csv`);
     } catch (error) {
-      log.error('[sync] importing new transactions failed most likely due to it already being in the DB');
+      log.error(
+        '[sync] importing new transactions failed most likely due to it already being in the DB'
+      );
       log.error(error);
     }
 
     try {
       await importTags(`${process.cwd()}/cache/tags.csv`);
     } catch (error) {
-      log.error('[sync] importing new tags failed most likely due to it already being in the DB');
+      log.error(
+        '[sync] importing new tags failed most likely due to it already being in the DB'
+      );
       log.error(error);
     }
-
 
     resetCacheStreams();
 
@@ -144,7 +165,7 @@ export async function parallelize(height: number) {
 export async function storeBlock(height: number, retry: number = 0) {
   try {
     const currentBlock = await block(height);
-    const {formattedBlock, input} = serializeBlock(currentBlock, height);
+    const { formattedBlock, input } = serializeBlock(currentBlock, height);
 
     streams.block.cache.write(input);
 
@@ -153,15 +174,22 @@ export async function storeBlock(height: number, retry: number = 0) {
     }
 
     if (height > 0) {
-      await storeTransactions(JSON.parse(formattedBlock.txs) as Array<string>, height);
+      await storeTransactions(
+        JSON.parse(formattedBlock.txs) as Array<string>,
+        height
+      );
     }
   } catch (error) {
     if (SIGKILL === false) {
       if (retry >= 25) {
-        log.info(`[snapshot] there were problems retrieving ${height}, restarting the server`);
+        log.info(
+          `[snapshot] there were problems retrieving ${height}, restarting the server`
+        );
         await startSync();
       } else {
-        log.info(`[snapshot] could not retrieve block at height ${height}, retrying`);
+        log.info(
+          `[snapshot] could not retrieve block at height ${height}, retrying`
+        );
         await storeBlock(height, retry + 1);
       }
     }
@@ -179,10 +207,17 @@ export async function storeTransactions(txs: Array<string>, height: number) {
   await Promise.all(batch);
 }
 
-export async function storeTransaction(tx: string, height: number, retry: boolean = true) {
+export async function storeTransaction(
+  tx: string,
+  height: number,
+  retry: boolean = true
+) {
   try {
     const currentTransaction = await transaction(tx);
-    const {formattedTransaction, preservedTags, input} = serializeTransaction(currentTransaction, height);
+    const { formattedTransaction, preservedTags, input } = serializeTransaction(
+      currentTransaction,
+      height
+    );
 
     streams.transaction.cache.write(input);
 
@@ -199,7 +234,13 @@ export async function storeTransaction(tx: string, height: number, retry: boolea
     }
   } catch (error) {
     console.log('');
-    log.info(`[database] could not retrieve tx ${tx} at height ${height} ${retry ? ', attempting to retrieve again' : ', missing tx stored in .rescan'}`);
+    log.info(
+      `[database] could not retrieve tx ${tx} at height ${height} ${
+        retry
+          ? ', attempting to retrieve again'
+          : ', missing tx stored in .rescan'
+      }`
+    );
     if (retry) {
       await storeTransaction(tx, height, false);
     } else {
@@ -211,7 +252,11 @@ export async function storeTransaction(tx: string, height: number, retry: boolea
   }
 }
 
-export async function processAns(id: string, height: number, retry: boolean = true) {
+export async function processAns(
+  id: string,
+  height: number,
+  retry: boolean = true
+) {
   try {
     const ansPayload = await getDataFromChunks(id);
     const ansTxs = await ansBundles.unbundleData(ansPayload.toString('utf-8'));
@@ -222,7 +267,9 @@ export async function processAns(id: string, height: number, retry: boolean = tr
     if (retry) {
       await processAns(id, height, false);
     } else {
-      log.info(`[database] malformed ANS payload at height ${height} for tx ${id}`);
+      log.info(
+        `[database] malformed ANS payload at height ${height} for tx ${id}`
+      );
       streams.rescan.cache.write(`${id}|${height}|ans\n`);
       if (storeSnapshot) {
         streams.rescan.snapshot.write(`${id}|${height}|ans\n`);
@@ -231,10 +278,13 @@ export async function processAns(id: string, height: number, retry: boolean = tr
   }
 }
 
-export async function processANSTransaction(ansTxs: Array<DataItemJson>, height: number) {
+export async function processANSTransaction(
+  ansTxs: Array<DataItemJson>,
+  height: number
+) {
   for (let i = 0; i < ansTxs.length; i++) {
     const ansTx = ansTxs[i];
-    const {ansTags, input} = serializeAnsTransaction(ansTx, height);
+    const { ansTags, input } = serializeAnsTransaction(ansTx, height);
 
     streams.transaction.cache.write(input);
 
@@ -244,7 +294,7 @@ export async function processANSTransaction(ansTxs: Array<DataItemJson>, height:
 
     for (let ii = 0; ii < ansTags.length; ii++) {
       const ansTag = ansTags[ii];
-      const {name, value} = ansTag;
+      const { name, value } = ansTag;
 
       const tag: DatabaseTag = {
         tx_id: ansTx.id,
@@ -267,7 +317,7 @@ export async function processANSTransaction(ansTxs: Array<DataItemJson>, height:
 export function storeTags(tx_id: string, tags: Array<Tag>) {
   for (let i = 0; i < tags.length; i++) {
     const tag = tags[i];
-    const {input} = serializeTags(tx_id, i, tag);
+    const { input } = serializeTags(tx_id, i, tag);
     streams.tags.cache.write(input);
     if (storeSnapshot) {
       streams.tags.snapshot.write(input);
@@ -275,11 +325,12 @@ export function storeTags(tx_id: string, tags: Array<Tag>) {
   }
 }
 
-
 export function signalHook() {
   if (!TestSuite) {
     process.on('SIGINT', () => {
-      log.info('[database] ensuring all blocks are stored before exit, you may see some extra output in console');
+      log.info(
+        '[database] ensuring all blocks are stored before exit, you may see some extra output in console'
+      );
       SIGKILL = true;
       setInterval(() => {
         if (SIGINT === false) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6082,6 +6082,11 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
+obuf@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
+  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -6384,6 +6389,13 @@ pg-connection-string@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-copy-streams@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/pg-copy-streams/-/pg-copy-streams-5.1.1.tgz#012f48c332cc31490aa0b5330bc571795963230f"
+  integrity sha512-ieW6JuiIo/4WQ7n+Wevr9zYvpM1AwUs6EwNCCA0VgKZ6ZQ7Y9k3IW00vqc6svX9FtENhbaTbLN7MxekraCrbfg==
+  dependencies:
+    obuf "^1.1.2"
 
 pg-int8@1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,6 +1340,23 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pg-copy-streams@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/pg-copy-streams/-/pg-copy-streams-1.2.1.tgz#f598cee10b59c20c8f155358bd99a6c438c42aae"
+  integrity sha512-7gsqXeYd4CypX4ZslvOhCuquL6Uo6B/ariCxw67fw6k+YL/Y1XncraDN/7qVlbM5WE5tmhxPxmacufrZ1/iloQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/pg" "*"
+
+"@types/pg@*":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.1.tgz#099450b8dc977e8197a44f5229cedef95c8747f9"
+  integrity sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/pg@^7.14.11":
   version "7.14.11"
   resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.14.11.tgz#daf5555504a1f7af4263df265d91f140fece52e3"
@@ -6407,7 +6424,7 @@ pg-pool@^3.3.0:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.3.0.tgz#12d5c7f65ea18a6e99ca9811bd18129071e562fc"
   integrity sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==
 
-pg-protocol@^1.2.0, pg-protocol@^1.5.0:
+pg-protocol@*, pg-protocol@^1.2.0, pg-protocol@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
   integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==


### PR DESCRIPTION
Rebased over #96, I'll re-rebase after that gets merged.

But the problem I'm hitting is stuff like this, and for parts which can fail, should fail. The stack gets usually lost in async functions (not in Promises) and a series of them, makes debugging very tedious.

```
yarn start
yarn run v1.22.10
$ npm run migrate:latest && node dist/src/Gateway.js

> @arweave/gateway@1.0.0 migrate:latest
> knex migrate:latest

Requiring external module ts-node/register
Already up to date
info: [app] started on http://localhost:3000
info: [database] starting sync, parallelization is set to 2
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

Error: connect ECONNREFUSED 163.47.11.64:1984
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1133:16) {
  errno: -61,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '163.47.11.64',
  port: 1984,
  response: undefined
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With this change I'm able to get somewhat started

```
yarn start
yarn run v1.22.10
$ npm run migrate:latest && node dist/src/Gateway.js

> @arweave/gateway@1.0.0 migrate:latest
> knex migrate:latest

Requiring external module ts-node/register
Already up to date
info: [app] started on http://localhost:3000
info: [database] starting sync, parallelization is set to 2
info: [database] syncing from block 0 to 730868
1/730868 blocks synced [                                                                                                    ] 0% 0.0sinfo: [snapshot] could not retrieve block at height 0, retrying
5/730868 blocks synced [                                                                                               ] 0% 343944.1sinfo: [snapshot] could not retrieve block at height 5, retrying
info: [snapshot] could not retrieve block at height 5, retrying
```