### PR TITLE
Fix empty filter

### DIFF
--- a/src/utility/filter.utility.ts
+++ b/src/utility/filter.utility.ts
@@ -18,6 +18,9 @@ export const filterPath = process.env.FILTER ?? 'app.filter.json';
 export const filters: Array<FilterI> = JSON.parse(read(filterPath) || '[]') as Array<FilterI>;
 
 export function validateTransaction(id: string, tags: Array<Tag>): boolean {
+  if (filters.length === 0) {
+    return true;
+  }
   for (let i = 0; i < filters.length; i++) {
     const filter = filters[i];
 


### PR DESCRIPTION
I'm not sure if this makes sense in production, but we use this gateway for testing with a local arweave-node and transactions are not populated to the DB.
Default filter is empty array, and it's treated like "not store any transactions". This PR reverts this behavior and makes it store every transaction.